### PR TITLE
Update pytest to 8.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.28.0
 pandas==1.5.0
-pytest==7.1.0
+pytest==8.3.3
 pillow==9.0.0
 numpy==1.23.0


### PR DESCRIPTION
This PR updates pytest from 7.1.0 to 8.3.3.
                
                Tested with Python 3.11